### PR TITLE
Add SEO sitemap and canonical tags

### DIFF
--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -12,7 +12,7 @@ class SitemapController extends Controller
 {
     public function index()
     {
-        $xml = Cache::remember('sitemap.xml.'.sha1(url('/')), now()->addHour(), function () {
+        $xml = Cache::remember('sitemap.xml.v2.'.sha1(url('/')), now()->addHour(), function () {
             $urls = [];
 
             foreach ($this->staticPaths() as $path) {
@@ -80,12 +80,8 @@ class SitemapController extends Controller
             '/peta',
             '/en/peta',
             '/monsters',
-            '/monster',
-            '/en/monster',
             '/items',
             '/en/items',
-            '/item',
-            '/en/item',
             '/skill',
             '/avatar',
             '/avatar/all',

--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -2,15 +2,126 @@
 
 namespace App\Http\Controllers;
 
+use App\Drop;
 use App\LogSearch;
+use App\Map;
+use App\Monster;
+use Illuminate\Support\Facades\Cache;
 
 class SitemapController extends Controller
 {
+    public function index()
+    {
+        $xml = Cache::remember('sitemap.xml.'.sha1(url('/')), now()->addHour(), function () {
+            $urls = [];
+
+            foreach ($this->staticPaths() as $path) {
+                $urls[] = $this->urlEntry(url($path), 'weekly', '0.7');
+            }
+
+            foreach ($this->monsterCategoryPaths() as $path) {
+                $urls[] = $this->urlEntry(url($path), 'weekly', '0.6');
+            }
+
+            Drop::select('id')->orderBy('id')->chunk(500, function ($items) use (&$urls) {
+                foreach ($items as $item) {
+                    $urls[] = $this->urlEntry(url('/item/'.$item->id), 'monthly', '0.8');
+                    $urls[] = $this->urlEntry(url('/en/item/'.$item->id), 'monthly', '0.8');
+                }
+            });
+
+            Monster::select('id')->orderBy('id')->chunk(500, function ($monsters) use (&$urls) {
+                foreach ($monsters as $monster) {
+                    $urls[] = $this->urlEntry(url('/monster/'.$monster->id), 'monthly', '0.8');
+                    $urls[] = $this->urlEntry(url('/en/monster/'.$monster->id), 'monthly', '0.8');
+                }
+            });
+
+            Map::select('id')->orderBy('id')->chunk(500, function ($maps) use (&$urls) {
+                foreach ($maps as $map) {
+                    $urls[] = $this->urlEntry(url('/peta/'.$map->id), 'monthly', '0.7');
+                    $urls[] = $this->urlEntry(url('/en/peta/'.$map->id), 'monthly', '0.7');
+                }
+            });
+
+            return '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL
+                .'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'.PHP_EOL
+                .implode('', $urls)
+                .'</urlset>'.PHP_EOL;
+        });
+
+        return response($xml, 200)->header('Content-Type', 'application/xml');
+    }
+
     public function show()
     {
         $searchTotal = LogSearch::count();
         $searches = LogSearch::latest()->select('q')->paginate(250);
 
         return view('sitemap.latest_search', compact('searches', 'searchTotal'));
+    }
+
+    private function staticPaths(): array
+    {
+        return [
+            '/',
+            '/en/',
+            '/registlet',
+            '/mq_exp',
+            '/refine',
+            '/refine/simulasi',
+            '/bgm',
+            '/kebijakan-privasi',
+            '/rules',
+            '/tentang-kami',
+            '/exp',
+            '/potensi/kalkulator',
+            '/leveling',
+            '/peta',
+            '/en/peta',
+            '/monsters',
+            '/monster',
+            '/en/monster',
+            '/items',
+            '/en/items',
+            '/item',
+            '/en/item',
+            '/skill',
+            '/avatar',
+            '/avatar/all',
+            '/cooking/berteman',
+            '/cooking/buff',
+            '/fill_stats/formula',
+            '/fill_stats/simulator',
+            '/prestasi',
+            '/appearance',
+            '/en/appearance',
+        ];
+    }
+
+    private function monsterCategoryPaths(): array
+    {
+        $paths = [];
+
+        foreach (['boss', 'mini_boss', 'normal'] as $type) {
+            $paths[] = '/monster/type/'.$type;
+            $paths[] = '/en/monster/type/'.$type;
+        }
+
+        foreach (['air', 'angin', 'bumi', 'api', 'gelap', 'cahaya', 'netral'] as $element) {
+            $paths[] = '/monster/unsur/'.$element;
+            $paths[] = '/en/monster/unsur/'.$element;
+        }
+
+        return $paths;
+    }
+
+    private function urlEntry(string $url, string $changefreq, string $priority): string
+    {
+        return '    <url>'.PHP_EOL
+            .'        <loc>'.e($url).'</loc>'.PHP_EOL
+            .'        <changefreq>'.$changefreq.'</changefreq>'.PHP_EOL
+            .'        <priority>'.$priority.'</priority>'.PHP_EOL
+            .'    </url>'.PHP_EOL;
     }
 }

--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -10,47 +10,65 @@ use Illuminate\Support\Facades\Cache;
 
 class SitemapController extends Controller
 {
+    private const MAX_URLS_PER_SITEMAP = 50000;
+
+    private const MODEL_RECORDS_PER_SITEMAP = 25000;
+
     public function index()
     {
-        $xml = Cache::remember('sitemap.xml.v2.'.sha1(url('/')), now()->addHour(), function () {
-            $urls = [];
+        $xml = Cache::remember('sitemap-index', now()->addHour(), function () {
+            $entries = $this->sitemapIndexEntry('/sitemap-pages.xml')
+                .$this->sitemapIndexEntries('/sitemap-items', Drop::count() * 2)
+                .$this->sitemapIndexEntries('/sitemap-monsters', Monster::count() * 2)
+                .$this->sitemapIndexEntries('/sitemap-maps', Map::count() * 2);
 
-            foreach ($this->staticPaths() as $path) {
-                $urls[] = $this->urlEntry(url($path), 'weekly', '0.7');
+            return $this->sitemapIndexXml($entries);
+        });
+
+        return $this->xmlResponse($xml);
+    }
+
+    public function pages()
+    {
+        $xml = Cache::remember('sitemap-pages', now()->addHour(), function () {
+            $urls = '';
+
+            foreach (array_unique(array_map($this->normalizePath(...), $this->staticPaths())) as $path) {
+                $urls .= $this->urlEntry($this->absoluteUrl($path), 'weekly', '0.7');
             }
 
             foreach ($this->monsterCategoryPaths() as $path) {
-                $urls[] = $this->urlEntry(url($path), 'weekly', '0.6');
+                $urls .= $this->urlEntry($this->absoluteUrl($path), 'weekly', '0.6');
             }
 
-            Drop::select('id')->orderBy('id')->chunk(500, function ($items) use (&$urls) {
-                foreach ($items as $item) {
-                    $urls[] = $this->urlEntry(url('/item/'.$item->id), 'monthly', '0.8');
-                    $urls[] = $this->urlEntry(url('/en/item/'.$item->id), 'monthly', '0.8');
-                }
-            });
-
-            Monster::select('id')->orderBy('id')->chunk(500, function ($monsters) use (&$urls) {
-                foreach ($monsters as $monster) {
-                    $urls[] = $this->urlEntry(url('/monster/'.$monster->id), 'monthly', '0.8');
-                    $urls[] = $this->urlEntry(url('/en/monster/'.$monster->id), 'monthly', '0.8');
-                }
-            });
-
-            Map::select('id')->orderBy('id')->chunk(500, function ($maps) use (&$urls) {
-                foreach ($maps as $map) {
-                    $urls[] = $this->urlEntry(url('/peta/'.$map->id), 'monthly', '0.7');
-                    $urls[] = $this->urlEntry(url('/en/peta/'.$map->id), 'monthly', '0.7');
-                }
-            });
-
-            return '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL
-                .'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'.PHP_EOL
-                .implode('', $urls)
-                .'</urlset>'.PHP_EOL;
+            return $this->urlSetXml($urls);
         });
 
-        return response($xml, 200)->header('Content-Type', 'application/xml');
+        return $this->xmlResponse($xml);
+    }
+
+    public function items(int $page = 1)
+    {
+        return $this->entitySitemap('sitemap-items-'.$page, Drop::query(), $page, function ($item) {
+            return $this->urlEntry($this->absoluteUrl('/item/'.$item->id), 'monthly', '0.8')
+                .$this->urlEntry($this->absoluteUrl('/en/item/'.$item->id), 'monthly', '0.8');
+        });
+    }
+
+    public function monsters(int $page = 1)
+    {
+        return $this->entitySitemap('sitemap-monsters-'.$page, Monster::query(), $page, function ($monster) {
+            return $this->urlEntry($this->absoluteUrl('/monster/'.$monster->id), 'monthly', '0.8')
+                .$this->urlEntry($this->absoluteUrl('/en/monster/'.$monster->id), 'monthly', '0.8');
+        });
+    }
+
+    public function maps(int $page = 1)
+    {
+        return $this->entitySitemap('sitemap-maps-'.$page, Map::query(), $page, function ($map) {
+            return $this->urlEntry($this->absoluteUrl('/peta/'.$map->id), 'monthly', '0.7')
+                .$this->urlEntry($this->absoluteUrl('/en/peta/'.$map->id), 'monthly', '0.7');
+        });
     }
 
     public function show()
@@ -59,6 +77,40 @@ class SitemapController extends Controller
         $searches = LogSearch::latest()->select('q')->paginate(250);
 
         return view('sitemap.latest_search', compact('searches', 'searchTotal'));
+    }
+
+    private function entitySitemap(string $cacheKey, $query, int $page, callable $urlBuilder)
+    {
+        $xml = Cache::remember($cacheKey, now()->addHour(), function () use ($query, $page, $urlBuilder) {
+            $urls = '';
+
+            foreach ($query->select('id')->orderBy('id')->forPage($page, self::MODEL_RECORDS_PER_SITEMAP)->cursor() as $record) {
+                $urls .= $urlBuilder($record);
+            }
+
+            return $this->urlSetXml($urls);
+        });
+
+        return $this->xmlResponse($xml);
+    }
+
+    private function sitemapIndexEntries(string $basePath, int $urlCount): string
+    {
+        $entries = '';
+        $pages = max(1, (int) ceil($urlCount / self::MAX_URLS_PER_SITEMAP));
+
+        for ($page = 1; $page <= $pages; $page++) {
+            $entries .= $this->sitemapIndexEntry($page === 1 ? $basePath.'.xml' : $basePath.'-'.$page.'.xml');
+        }
+
+        return $entries;
+    }
+
+    private function sitemapIndexEntry(string $path): string
+    {
+        return '    <sitemap>'.PHP_EOL
+            .'        <loc>'.$this->escapeXml($this->absoluteUrl($path)).'</loc>'.PHP_EOL
+            .'    </sitemap>'.PHP_EOL;
     }
 
     private function staticPaths(): array
@@ -115,9 +167,50 @@ class SitemapController extends Controller
     private function urlEntry(string $url, string $changefreq, string $priority): string
     {
         return '    <url>'.PHP_EOL
-            .'        <loc>'.e($url).'</loc>'.PHP_EOL
+            .'        <loc>'.$this->escapeXml($url).'</loc>'.PHP_EOL
             .'        <changefreq>'.$changefreq.'</changefreq>'.PHP_EOL
             .'        <priority>'.$priority.'</priority>'.PHP_EOL
             .'    </url>'.PHP_EOL;
+    }
+
+    private function urlSetXml(string $urls): string
+    {
+        return '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL
+            .'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'.PHP_EOL
+            .$urls
+            .'</urlset>'.PHP_EOL;
+    }
+
+    private function sitemapIndexXml(string $entries): string
+    {
+        return '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL
+            .'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'.PHP_EOL
+            .$entries
+            .'</sitemapindex>'.PHP_EOL;
+    }
+
+    private function xmlResponse(string $xml)
+    {
+        return response($xml, 200)->header('Content-Type', 'application/xml');
+    }
+
+    private function absoluteUrl(string $path): string
+    {
+        $baseUrl = rtrim(config('app.url'), '/');
+        $path = $this->normalizePath($path);
+
+        return $path === '/' ? $baseUrl : $baseUrl.$path;
+    }
+
+    private function normalizePath(string $path): string
+    {
+        $path = '/'.ltrim($path, '/');
+
+        return $path === '/' ? $path : rtrim($path, '/');
+    }
+
+    private function escapeXml(string $value): string
+    {
+        return htmlspecialchars($value, ENT_XML1 | ENT_COMPAT, 'UTF-8');
     }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow: /search
+
+Sitemap: https://toram-id.space/sitemap.xml

--- a/resources/views/layouts/tabler.blade.php
+++ b/resources/views/layouts/tabler.blade.php
@@ -48,7 +48,7 @@
     {{-- tw --}}
 
     @php
-        $shouldNoIndex = request()->query() || request()->is('search') || request()->is('en/search') || request()->is('latest_search') || request()->is('en/latest_search') || request()->is('profile*') || request()->is('secrets*');
+        $shouldNoIndex = ((request()->is('item') || request()->is('en/item')) && request()->has('name')) || (request()->is('leveling') && request()->has('level')) || request()->is('search') || request()->is('en/search') || request()->is('latest_search') || request()->is('en/latest_search') || request()->is('profile*') || request()->is('secrets*');
         $canonicalUrl = request()->is('item') && request()->query() ? url('/items') : request()->url();
         $canonicalUrl = request()->is('en/item') && request()->query() ? url('/en/items') : $canonicalUrl;
         $canonicalUrl = trim($__env->yieldContent('canonical', $canonicalUrl));

--- a/resources/views/layouts/tabler.blade.php
+++ b/resources/views/layouts/tabler.blade.php
@@ -47,7 +47,14 @@
     <meta name="twitter:description" content="@yield('description')">
     {{-- tw --}}
 
+    @php
+        $shouldNoIndex = request()->query() || request()->is('search') || request()->is('en/search') || request()->is('latest_search') || request()->is('en/latest_search') || request()->is('profile*') || request()->is('secrets*');
+        $robotsContent = trim($__env->yieldContent('robots', $shouldNoIndex ? 'noindex, follow' : 'index, follow'));
+    @endphp
+
     <meta name="google-site-verification" content="da3qNV1VnD0nhZNfFMx3Ov_6dnyvYMlUT7OChWqSbmY" />
+    <meta name="robots" content="{{ $robotsContent }}">
+    <link rel="canonical" href="{{ request()->url() }}" />
     <meta name="description" content="@yield('description') - RPG Toram Online Database & Wiki | Toram ID INFO">
     <meta name="keywords"
         content="Toram Id, RPG Toram Online, Toram Online Wiki, Toram Online Database, Drop list, Monster list, Fill Stat formula, Fill stat simulator, calculator, forum, Toram Online Indonesia, MMORPG Android and iOS game" />

--- a/resources/views/layouts/tabler.blade.php
+++ b/resources/views/layouts/tabler.blade.php
@@ -49,12 +49,25 @@
 
     @php
         $shouldNoIndex = request()->query() || request()->is('search') || request()->is('en/search') || request()->is('latest_search') || request()->is('en/latest_search') || request()->is('profile*') || request()->is('secrets*');
+        $canonicalUrl = request()->is('item') && request()->query() ? url('/items') : request()->url();
+        $canonicalUrl = request()->is('en/item') && request()->query() ? url('/en/items') : $canonicalUrl;
+        $canonicalUrl = trim($__env->yieldContent('canonical', $canonicalUrl));
+        $path = request()->path();
+        $hasEnglishMirror = ! request()->query() && request()->is('/', 'peta', 'peta/*', 'items', 'items/*', 'item', 'item/*', 'monster/*', 'appearance', 'appearance/*', 'en', 'en/peta', 'en/peta/*', 'en/items', 'en/items/*', 'en/item', 'en/item/*', 'en/monster/*', 'en/appearance', 'en/appearance/*');
+        $idPath = request()->segment(1) === 'en' ? preg_replace('#^en/?#', '', $path) : $path;
+        $idUrl = $idPath === '' ? url('/') : url('/'.$idPath);
+        $enUrl = $idPath === '' ? url('/en') : url('/en/'.$idPath);
         $robotsContent = trim($__env->yieldContent('robots', $shouldNoIndex ? 'noindex, follow' : 'index, follow'));
     @endphp
 
     <meta name="google-site-verification" content="da3qNV1VnD0nhZNfFMx3Ov_6dnyvYMlUT7OChWqSbmY" />
     <meta name="robots" content="{{ $robotsContent }}">
-    <link rel="canonical" href="{{ request()->url() }}" />
+    <link rel="canonical" href="{{ $canonicalUrl }}" />
+    @if ($hasEnglishMirror)
+        <link rel="alternate" hreflang="id" href="{{ $idUrl }}" />
+        <link rel="alternate" hreflang="en" href="{{ $enUrl }}" />
+        <link rel="alternate" hreflang="x-default" href="{{ $idUrl }}" />
+    @endif
     <meta name="description" content="@yield('description') - RPG Toram Online Database & Wiki | Toram ID INFO">
     <meta name="keywords"
         content="Toram Id, RPG Toram Online, Toram Online Wiki, Toram Online Database, Drop list, Monster list, Fill Stat formula, Fill stat simulator, calculator, forum, Toram Online Indonesia, MMORPG Android and iOS game" />

--- a/resources/views/layouts/webview.blade.php
+++ b/resources/views/layouts/webview.blade.php
@@ -48,13 +48,26 @@
 <!-- // open graph -->
 @php
     $shouldNoIndex = request()->query() || request()->is('search') || request()->is('en/search') || request()->is('latest_search') || request()->is('en/latest_search') || request()->is('profile*') || request()->is('secrets*');
+    $canonicalUrl = request()->is('item') && request()->query() ? url('/items') : request()->url();
+    $canonicalUrl = request()->is('en/item') && request()->query() ? url('/en/items') : $canonicalUrl;
+    $canonicalUrl = trim($__env->yieldContent('canonical', $canonicalUrl));
+    $path = request()->path();
+    $hasEnglishMirror = ! request()->query() && request()->is('/', 'peta', 'peta/*', 'items', 'items/*', 'item', 'item/*', 'monster/*', 'appearance', 'appearance/*', 'en', 'en/peta', 'en/peta/*', 'en/items', 'en/items/*', 'en/item', 'en/item/*', 'en/monster/*', 'en/appearance', 'en/appearance/*');
+    $idPath = request()->segment(1) === 'en' ? preg_replace('#^en/?#', '', $path) : $path;
+    $idUrl = $idPath === '' ? url('/') : url('/'.$idPath);
+    $enUrl = $idPath === '' ? url('/en') : url('/en/'.$idPath);
     $robotsContent = trim($__env->yieldContent('robots', $shouldNoIndex ? 'noindex, follow' : 'index, follow'));
 @endphp
 <meta name="google-site-verification" content="da3qNV1VnD0nhZNfFMx3Ov_6dnyvYMlUT7OChWqSbmY" />
 <meta name="description" content="@yield('description')">
 <meta name='language' content='id_id'/>
 <meta name="robots" content="{{ $robotsContent }}">
-<link rel="canonical" href="{{ request()->url() }}" />
+<link rel="canonical" href="{{ $canonicalUrl }}" />
+@if ($hasEnglishMirror)
+    <link rel="alternate" hreflang="id" href="{{ $idUrl }}" />
+    <link rel="alternate" hreflang="en" href="{{ $enUrl }}" />
+    <link rel="alternate" hreflang="x-default" href="{{ $idUrl }}" />
+@endif
 <meta content='follow, all' name='alexabot'/>
 <meta content='id' name='language'/>
 <meta content='Indonesia' name='geo.placename'/>

--- a/resources/views/layouts/webview.blade.php
+++ b/resources/views/layouts/webview.blade.php
@@ -46,10 +46,15 @@
 <meta property="fb:app_id" content="2008283499456981"/>
 
 <!-- // open graph -->
+@php
+    $shouldNoIndex = request()->query() || request()->is('search') || request()->is('en/search') || request()->is('latest_search') || request()->is('en/latest_search') || request()->is('profile*') || request()->is('secrets*');
+    $robotsContent = trim($__env->yieldContent('robots', $shouldNoIndex ? 'noindex, follow' : 'index, follow'));
+@endphp
 <meta name="google-site-verification" content="da3qNV1VnD0nhZNfFMx3Ov_6dnyvYMlUT7OChWqSbmY" />
 <meta name="description" content="@yield('description')">
 <meta name='language' content='id_id'/>
-<meta name='robots' content='all,index,follow'/>
+<meta name="robots" content="{{ $robotsContent }}">
+<link rel="canonical" href="{{ request()->url() }}" />
 <meta content='follow, all' name='alexabot'/>
 <meta content='id' name='language'/>
 <meta content='Indonesia' name='geo.placename'/>
@@ -68,7 +73,7 @@
 
 <script type='application/ld+json'>
 {
-	 "@context": "http://schema.org",
+	 "@@context": "http://schema.org",
 	 "@type": "WebSite",
 	 "url": "{{ url('/') }}"
  }
@@ -139,7 +144,7 @@ if('serviceWorker' in navigator)
  <script src="/assets/js/vendors/bootstrap.bundle.min.js"></script>
 
 
-@if(env('APP_ENV') === 'production')
+@production
 <!-- Google Analytics -->
 <script>
 window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
@@ -148,6 +153,6 @@ ga('send', 'pageview');
 </script>
 <script async src='https://www.google-analytics.com/analytics.js'></script>
 <!-- End Google Analytics -->
-@endif
+@endproduction
   </body>
 </html>

--- a/resources/views/layouts/webview.blade.php
+++ b/resources/views/layouts/webview.blade.php
@@ -47,7 +47,7 @@
 
 <!-- // open graph -->
 @php
-    $shouldNoIndex = request()->query() || request()->is('search') || request()->is('en/search') || request()->is('latest_search') || request()->is('en/latest_search') || request()->is('profile*') || request()->is('secrets*');
+    $shouldNoIndex = ((request()->is('item') || request()->is('en/item')) && request()->has('name')) || (request()->is('leveling') && request()->has('level')) || request()->is('search') || request()->is('en/search') || request()->is('latest_search') || request()->is('en/latest_search') || request()->is('profile*') || request()->is('secrets*');
     $canonicalUrl = request()->is('item') && request()->query() ? url('/items') : request()->url();
     $canonicalUrl = request()->is('en/item') && request()->query() ? url('/en/items') : $canonicalUrl;
     $canonicalUrl = trim($__env->yieldContent('canonical', $canonicalUrl));

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,6 +33,13 @@ use Illuminate\Support\Facades\Route;
 
 Route::view('/', 'toram');
 Route::get('/sitemap.xml', [SitemapController::class, 'index']);
+Route::get('/sitemap-pages.xml', [SitemapController::class, 'pages']);
+Route::get('/sitemap-items.xml', [SitemapController::class, 'items']);
+Route::get('/sitemap-items-{page}.xml', [SitemapController::class, 'items'])->whereNumber('page');
+Route::get('/sitemap-monsters.xml', [SitemapController::class, 'monsters']);
+Route::get('/sitemap-monsters-{page}.xml', [SitemapController::class, 'monsters'])->whereNumber('page');
+Route::get('/sitemap-maps.xml', [SitemapController::class, 'maps']);
+Route::get('/sitemap-maps-{page}.xml', [SitemapController::class, 'maps'])->whereNumber('page');
 
 /*
 | -- English Route

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::view('/', 'toram');
+Route::get('/sitemap.xml', [SitemapController::class, 'index']);
 
 /*
 | -- English Route


### PR DESCRIPTION
## Summary
- Add `/sitemap.xml` with cached canonical URLs for static pages, items, monsters, maps, and mirrored EN routes.
- Add sitemap discovery in `robots.txt`.
- Add canonical and robots meta handling to public layouts so query/search-like pages use `noindex, follow`.

## Test plan
- [x] `php -l app/Http/Controllers/SitemapController.php`
- [x] `php artisan route:list --path=sitemap`
- [x] Sitemap controller returns `200` with `application/xml`
- [x] `vendor/bin/pint --dirty`
- [x] `php artisan test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated XML sitemap generation to improve search engine discovery
  * Implemented dynamic robots meta tags and canonical URL support for better search engine indexing control
  * Updated robots configuration to reference the new sitemap

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akrindev/tiramisu2/pull/35)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->