### PR TITLE
Serve sitemaps without session cookies

### DIFF
--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -191,7 +191,9 @@ class SitemapController extends Controller
 
     private function xmlResponse(string $xml)
     {
-        return response($xml, 200)->header('Content-Type', 'application/xml');
+        return response($xml, 200)
+            ->header('Content-Type', 'application/xml')
+            ->header('Cache-Control', 'public, max-age=3600');
     }
 
     private function absoluteUrl(string $path): string

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,8 +17,13 @@ use App\Http\Controllers\SendMailController;
 use App\Http\Controllers\SitemapController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\XpController;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 /*
 |--------------------------------------------------------------------------
@@ -32,14 +37,22 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::view('/', 'toram');
-Route::get('/sitemap.xml', [SitemapController::class, 'index']);
-Route::get('/sitemap-pages.xml', [SitemapController::class, 'pages']);
-Route::get('/sitemap-items.xml', [SitemapController::class, 'items']);
-Route::get('/sitemap-items-{page}.xml', [SitemapController::class, 'items'])->whereNumber('page');
-Route::get('/sitemap-monsters.xml', [SitemapController::class, 'monsters']);
-Route::get('/sitemap-monsters-{page}.xml', [SitemapController::class, 'monsters'])->whereNumber('page');
-Route::get('/sitemap-maps.xml', [SitemapController::class, 'maps']);
-Route::get('/sitemap-maps-{page}.xml', [SitemapController::class, 'maps'])->whereNumber('page');
+Route::withoutMiddleware([
+    EncryptCookies::class,
+    AddQueuedCookiesToResponse::class,
+    StartSession::class,
+    ShareErrorsFromSession::class,
+    ValidateCsrfToken::class,
+])->group(function () {
+    Route::get('/sitemap.xml', [SitemapController::class, 'index']);
+    Route::get('/sitemap-pages.xml', [SitemapController::class, 'pages']);
+    Route::get('/sitemap-items.xml', [SitemapController::class, 'items']);
+    Route::get('/sitemap-items-{page}.xml', [SitemapController::class, 'items'])->whereNumber('page');
+    Route::get('/sitemap-monsters.xml', [SitemapController::class, 'monsters']);
+    Route::get('/sitemap-monsters-{page}.xml', [SitemapController::class, 'monsters'])->whereNumber('page');
+    Route::get('/sitemap-maps.xml', [SitemapController::class, 'maps']);
+    Route::get('/sitemap-maps-{page}.xml', [SitemapController::class, 'maps'])->whereNumber('page');
+});
 
 /*
 | -- English Route


### PR DESCRIPTION
## Summary
- Serve sitemap routes without Laravel session/cookie middleware so crawlers receive clean XML responses.
- Add public cache headers to sitemap XML responses.

## Test plan
- [x] `php -l app/Http/Controllers/SitemapController.php`
- [x] `php artisan route:list --path=sitemap`
- [x] Render sitemap index and section XML locally
- [x] `vendor/bin/pint --dirty`
- [x] `php artisan test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)